### PR TITLE
🚧: add BackButton apply.

### DIFF
--- a/src/components/common/atoms/BackButton/BackButton.stories.mdx
+++ b/src/components/common/atoms/BackButton/BackButton.stories.mdx
@@ -1,0 +1,21 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+
+import BackButton from '.';
+
+<Meta title="atoms/BackButton" component={BackButton} />
+
+# BackButton
+
+모든 페이지에서 사용되어지는 뒤로가기 버튼 컴포넌트 입니다.
+
+# Props
+
+```ts
+
+type ButtonSize = 'small' | 'medium' | 'large';
+
+interface BackButtonProps {
+  // BackButton의 사이즈 단위! 'small', 'medium','large'가 있다.
+  buttonSize: ButtonSize;
+}
+```

--- a/src/components/common/atoms/BackButton/BackButton.stories.tsx
+++ b/src/components/common/atoms/BackButton/BackButton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta } from '@storybook/react';
+import {
+  within,
+  userEvent,
+} from '@storybook/testing-library';
+import React from 'react';
+
+import BackButton from '.';
+
+const meta: Meta<typeof BackButton> = {
+  title: 'atoms/BackButton',
+  component: BackButton,
+};
+
+export default meta;
+
+export const PrimaryBackButton = {
+  render: () => <BackButton buttonSize="small" />,
+  play: async ({ canvasElement, step }: any) => {
+    const canvas = within(canvasElement);
+
+    const backButton = canvas.getByRole('button');
+
+    await step('clicked Login BackButton', async () => {
+      await backButton.click();
+    });
+
+    await userEvent.type(
+      backButton,
+      'router push prev page',
+      {
+        delay: 100,
+      },
+    );
+  },
+};

--- a/src/components/common/atoms/BackButton/index.tsx
+++ b/src/components/common/atoms/BackButton/index.tsx
@@ -1,0 +1,68 @@
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
+
+import Icon from '../Icon';
+
+type ButtonSize = 'small' | 'medium' | 'large';
+
+interface BackButtonProps {
+  buttonSize: ButtonSize;
+}
+
+const StyledBackButton = styled.button<BackButtonProps>`
+  border: none;
+  outline: none;
+  background: transparent;
+  cursor: pointer;
+  width: auto;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+
+  width: ${({ buttonSize }) => {
+    switch (buttonSize) {
+      case 'small':
+        return '24px';
+      case 'medium':
+        return '32px';
+      case 'large':
+        return '48px';
+      default:
+        return '32px';
+    }
+  }};
+
+  height: ${({ buttonSize }) => {
+    switch (buttonSize) {
+      case 'small':
+        return '24px';
+      case 'medium':
+        return '32px';
+      case 'large':
+        return '48px';
+      default:
+        return '32px';
+    }
+  }};
+`;
+
+const BackButton = ({ buttonSize }: BackButtonProps) => {
+  const router = useRouter();
+
+  return (
+    <StyledBackButton
+      type="button"
+      onClick={() => router.back()}
+      aria-label="back button"
+      buttonSize={buttonSize}
+    >
+      <Icon
+        iconName="backButtonIcon"
+        color="#000"
+        iconSize={buttonSize}
+      />
+    </StyledBackButton>
+  );
+};
+
+export default BackButton;


### PR DESCRIPTION
back-button을 감싸는 부분은 웹 접근성을 고려하여 뒤로가는 용도로 사용하기 위해 button 태그를 사용하였습니다.
추가적으로 button 태그의 기본적인 스타일을 제거하여 onClick 메서드만 동작하도록 하는 용도로 사용했어요.