### PR TITLE
♻️ refac: Icon components modify props, storybook setting path alias

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -26,13 +26,19 @@ const config: StorybookConfig = {
 
     // Add json, svg extension
     config.resolve.extensions = config.resolve.extensions
-    ? [...config.resolve.extensions, '.json', '.svg']
-    : ['.json', '.svg'];
-
+      ? [...config.resolve.extensions, '.json', '.svg']
+      : ['.json', '.svg'];
 
     // Add alias for iconDist directory
     config.resolve.alias = {
       '@/assets': path.resolve(__dirname, '../src/assets/'),
+      '@/components': path.resolve(
+        __dirname,
+        '../src/components/',
+      ),
+      '@/pages': path.resolve(__dirname, '../src/pages/'),
+      '@/store': path.resolve(__dirname, '../src/store/'),
+      '@/styles': path.resolve(__dirname, '../src/styles/'),
       '@/utils': path.resolve(__dirname, '../src/utils/'),
     };
 
@@ -55,7 +61,6 @@ const config: StorybookConfig = {
         use: ['@svgr/webpack'],
       },
     ];
-
 
     return config;
   },

--- a/src/components/common/atoms/Icon/Icon.stories.mdx
+++ b/src/components/common/atoms/Icon/Icon.stories.mdx
@@ -1,6 +1,11 @@
-import { Meta, Canvas, ArgsTable, Story } from "@storybook/blocks";
+import {
+  Meta,
+  Canvas,
+  ArgsTable,
+  Story,
+} from '@storybook/blocks';
 
-import Icon from '.'
+import Icon from '.';
 
 <Meta title="atoms/Icon" component={Icon} />
 
@@ -36,6 +41,11 @@ interface IconProps {
    * custom class 하고 싶은 경우 props로 받아 적용.
    */
   className?: string;
+
+  /**
+   * Icon을 클릭했을때 동작하는 onclick 함수.
+   */
+  onClick?: () => void;
 }
 ```
 
@@ -44,5 +54,9 @@ interface IconProps {
 - 아이콘 예제입니다.
 
 <Canvas>
-  <Icon iconName="homeIcon" iconSize="small" color="grey040" />
+  <Icon
+    iconName="homeIcon"
+    iconSize="small"
+    color="grey040"
+  />
 </Canvas>

--- a/src/components/common/atoms/Icon/Icon.stories.tsx
+++ b/src/components/common/atoms/Icon/Icon.stories.tsx
@@ -9,20 +9,25 @@ const meta: Meta<typeof Icon> = {
 
 export default meta;
 
-const PrimitiveSVGIcons = () => (
-  <>
-    <Icon
-      iconName="homeIcon"
-      iconSize="small"
-      color="grey040"
-    />
-    <Icon
-      iconName="searchIcon"
-      iconSize="small"
-      color="grey040"
-    />
-  </>
-);
+const PrimitiveSVGIcons = () => {
+  // eslint-disable-next-line no-console
+  const handleIconClick = () => console.log('clicked Icon');
+  return (
+    <>
+      <Icon
+        iconName="homeIcon"
+        iconSize="small"
+        color="grey040"
+        onClick={handleIconClick}
+      />
+      <Icon
+        iconName="searchIcon"
+        iconSize="small"
+        color="grey040"
+      />
+    </>
+  );
+};
 
 export const PrimarySVG = {
   render: () => <PrimitiveSVGIcons />,

--- a/src/components/common/atoms/Icon/index.tsx
+++ b/src/components/common/atoms/Icon/index.tsx
@@ -17,9 +17,9 @@ interface IconProps {
 
 type StyledIconProps = {
   iconSize: IconSize;
-} & React.HTMLProps<HTMLDivElement>;
+} & React.HTMLProps<HTMLButtonElement>;
 
-const StyledIcon = styled.div<StyledIconProps>`
+const StyledIcon = styled.button<StyledIconProps>`
   cursor: pointer;
 
   width: ${({ iconSize }) => {

--- a/src/components/common/atoms/Icon/index.tsx
+++ b/src/components/common/atoms/Icon/index.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useMemo } from 'react';
+import styled from 'styled-components';
 
 import SVGComponents, {
   SVGIconKeys,
@@ -11,13 +12,48 @@ interface IconProps {
   color: string;
   iconSize: IconSize;
   className?: string;
+  onClick?: () => void;
 }
+
+type StyledIconProps = {
+  iconSize: IconSize;
+} & React.HTMLProps<HTMLDivElement>;
+
+const StyledIcon = styled.div<StyledIconProps>`
+  cursor: pointer;
+
+  width: ${({ iconSize }) => {
+    switch (iconSize) {
+      case 'small':
+        return '24px';
+      case 'medium':
+        return '32px';
+      case 'large':
+        return '64px';
+      default:
+        return '32px'; // 기본값
+    }
+  }};
+  height: ${({ iconSize }) => {
+    switch (iconSize) {
+      case 'small':
+        return '24px';
+      case 'medium':
+        return '32px';
+      case 'large':
+        return '64px';
+      default:
+        return '32px'; // 기본값
+    }
+  }};
+`;
 
 const Icon = ({
   iconName,
   color,
   iconSize,
   className,
+  onClick,
 }: IconProps) => {
   const IconComponent = useMemo(
     () => SVGComponents[iconName],
@@ -26,12 +62,13 @@ const Icon = ({
 
   return (
     <Suspense fallback={<div>LoadingSpinner....</div>}>
-      <IconComponent
-        color={color}
-        width={iconSize}
-        height={iconSize}
+      <StyledIcon
+        iconSize={iconSize}
         className={className}
-      />
+        onClick={onClick}
+      >
+        <IconComponent color={color} />
+      </StyledIcon>
     </Suspense>
   );
 };

--- a/src/utils/iconMap.ts
+++ b/src/utils/iconMap.ts
@@ -11,7 +11,9 @@ export const lazy = (componentImportFn: Function) =>
 export type SVGIconKeys =
   | 'homeIcon'
   | 'searchIcon'
-  | 'backButtonIcon'; // 필요한 키들을 추가
+  | 'backButtonIcon'
+  | 'notificationIcon'
+  | 'settingsIcon'; // 필요한 키들을 추가
 
 const SVG_ICON_MAP = {
   homeIcon: lazy(() => import('@/assets/icon/home.svg')),
@@ -20,6 +22,12 @@ const SVG_ICON_MAP = {
   ),
   backButtonIcon: lazy(
     () => import('@/assets/icon/back-button.svg'),
+  ),
+  notificationIcon: lazy(
+    () => import('@/assets/icon/notification.svg'),
+  ),
+  settingsIcon: lazy(
+    () => import('@/assets/icon/settings.svg'),
   ),
 };
 


### PR DESCRIPTION
home UI 에서 navigation을 구현하면서 먼저 icon 컴포넌트를 수정해야 한다고 느껴서 수정했어요..!

기존에 아이콘 컴포넌트에 width, height 값이 정상적으로 동작하지 않아 수정했고
아이콘을 클릭했을때 onclick 리스너를 달도록 하기 위해 아이콘을 버튼 컴포넌트로 한 번 랩핑했어요~