### PR TITLE
🚧 feat: create Indicator component

### DIFF
--- a/src/components/common/atoms/Indicator/Indicator.stories.mdx
+++ b/src/components/common/atoms/Indicator/Indicator.stories.mdx
@@ -1,0 +1,32 @@
+import { action } from '@storybook/addon-actions';
+import { Meta, Canvas, Story } from '@storybook/blocks';
+
+import Indicator from '.';
+
+<Meta title="atoms/Indicator" component={Indicator} />
+
+# Indicator
+
+홈 페이지에서 사용되어지는 Indiactor 컴포넌트 입니다.
+
+# Props
+
+```ts
+interface IndicatorProps {
+  // Indicator 개수
+  nums: number;
+  // 현재 클릭된 indicator에 따라 카드 내용이 변경되도록 하는 콜백함수
+  handleChangeCard: (clickedIdx: number) => void;
+}
+```
+
+### Indicator
+
+<h4>* Indicator 예시 *</h4>
+
+<div>
+  <Indicator
+    nums={3}
+    handleChangeCard={action('change Card')}
+  />
+</div>

--- a/src/components/common/atoms/Indicator/Indicator.stories.tsx
+++ b/src/components/common/atoms/Indicator/Indicator.stories.tsx
@@ -1,0 +1,21 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta } from '@storybook/react';
+import React from 'react';
+
+import Indicator from '.';
+
+const meta: Meta<typeof Indicator> = {
+  title: 'atoms/Indicator',
+  component: Indicator,
+};
+
+export default meta;
+
+export const CommonIndicator = {
+  render: () => (
+    <Indicator
+      nums={3}
+      handleChangeCard={action('change Card')}
+    />
+  ),
+};

--- a/src/components/common/atoms/Indicator/index.tsx
+++ b/src/components/common/atoms/Indicator/index.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import { flexbox } from '@/styles/mixin';
+
+interface IndicatorProps {
+  nums: number;
+  // eslint-disable-next-line no-unused-vars
+  handleChangeCard: (clickedIdx: number) => void;
+}
+
+const IndicatorWrapper = styled.div`
+  ${flexbox({})}
+  width: 100%;
+  gap: 4px;
+`;
+const StyledIndicator = styled.button<{
+  isActive: boolean;
+}>`
+  width: ${({ isActive }) => (isActive ? 27 : 7)}px;
+  height: 7px;
+  border-radius: ${({ isActive }) =>
+    isActive ? '4px' : '50%'};
+  background: ${({ isActive }) =>
+    isActive ? 'silver' : 'gray'};
+
+  border: none;
+  outline: none;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+`;
+
+const Indicator = ({
+  nums,
+  handleChangeCard,
+}: IndicatorProps) => {
+  const [count, setCount] = useState(0);
+
+  const handleClickIndicator = (clickedIdx: number) => {
+    setCount(clickedIdx);
+    // 바코드 변경
+    handleChangeCard(clickedIdx);
+  };
+
+  return (
+    <IndicatorWrapper>
+      {Array.from({ length: nums }).map((_, idx) => (
+        <StyledIndicator
+          key={`indicator-${idx + 1}번째`}
+          isActive={count === idx}
+          onClick={() => handleClickIndicator(idx)}
+        />
+      ))}
+    </IndicatorWrapper>
+  );
+};
+
+export default Indicator;


### PR DESCRIPTION
<img width="1074" alt="indicator" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/1dee66a4-50c9-4358-959a-a8cff21d6c62">

현재는 위 홈페이지 바코드 카드 영역 내에서만 사용되지만 따로 관리하려다가 다른 곳에서도 뭔가 쓰여질 것 같은 컴포넌트처럼 생각되어서 우선 atoms에다가 만들었어요!

해당 indicator를 클릭할때마다 바코드 내용도 전부 바껴야 하기 때문에 콜백함수를 props로 받았다는 점 말고는 다른 컴포넌트와 유사해요