### PR TITLE
🚧 feat: create barcode component

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -36,6 +36,7 @@ const config: StorybookConfig = {
         __dirname,
         '../src/components/',
       ),
+      '@/hooks': path.resolve(__dirname, '../src/hooks/'),
       '@/pages': path.resolve(__dirname, '../src/pages/'),
       '@/store': path.resolve(__dirname, '../src/store/'),
       '@/styles': path.resolve(__dirname, '../src/styles/'),

--- a/src/components/common/atoms/Barcode/Barcode.stories.mdx
+++ b/src/components/common/atoms/Barcode/Barcode.stories.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+
+import Barcode from '.';
+
+<Meta title="atoms/Barcode" component={Barcode} />
+
+# Barcode
+
+홈 페이지에서 바코드 컴포넌트 입니다.
+
+# Props
+
+```ts
+// bwipjs 라이브러리로 만들어낸 바코드 스트링타입.
+barcodeDataURL: string;
+// 바코드 만료기간
+expiryDate: string;
+// 바코드 재생성 함수
+regenerateBarcode: () => void;
+```

--- a/src/components/common/atoms/Barcode/Barcode.stories.tsx
+++ b/src/components/common/atoms/Barcode/Barcode.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta } from '@storybook/react';
+import React from 'react';
+
+import useBarcode from '@/hooks/useBarcode';
+
+import Barcode from '.';
+
+const meta: Meta<typeof Barcode> = {
+  title: 'atoms/Barcode',
+  component: Barcode,
+};
+
+export default meta;
+
+export const CommonBarcode = () => {
+  const { barcodeDataURL, expiryDate, regenerateBarcode } =
+    useBarcode();
+
+  return (
+    <Barcode
+      barcodeDataURL={barcodeDataURL}
+      expiryDate={expiryDate}
+      regenerateBarcode={regenerateBarcode}
+    />
+  );
+};

--- a/src/components/common/atoms/Barcode/index.tsx
+++ b/src/components/common/atoms/Barcode/index.tsx
@@ -1,0 +1,58 @@
+import Image from 'next/image';
+import styled from 'styled-components';
+
+import { flexbox } from '@/styles/mixin';
+
+import Icon from '../Icon';
+
+interface BarcodeProps {
+  barcodeDataURL: string | null;
+  expiryDate: string;
+  regenerateBarcode: () => void;
+}
+
+const BarcodeWrapper = styled.div`
+  ${flexbox({ dir: 'column', jc: 'center', ai: 'center' })}
+  width: 364px;
+  height: 83px;
+  position: relative;
+
+  border-radius: 0 0 10px 10px;
+  padding: 9px 0;
+`;
+
+const BarcodeInfo = styled.div`
+  ${flexbox({ ai: 'center' })}
+  margin-top: 5px;
+  letter-spacing: 3px;
+`;
+
+const Barcode = ({
+  barcodeDataURL,
+  expiryDate,
+  regenerateBarcode,
+}: BarcodeProps) => (
+  <BarcodeWrapper>
+    {barcodeDataURL && (
+      <>
+        <Image
+          width={216}
+          height={49.5}
+          src={barcodeDataURL}
+          alt="Ticket Barcode"
+        />
+        <BarcodeInfo>
+          <span>{expiryDate}</span>
+          {/* Icon 차후에 refresh icon으로 변경예정. */}
+          <Icon
+            iconName="searchIcon"
+            iconSize="small"
+            color="black"
+            onClick={regenerateBarcode}
+          />
+        </BarcodeInfo>
+      </>
+    )}
+  </BarcodeWrapper>
+);
+export default Barcode;

--- a/src/hooks/useBarcode.tsx
+++ b/src/hooks/useBarcode.tsx
@@ -1,0 +1,81 @@
+import bwipjs from 'bwip-js';
+import { useEffect, useState } from 'react';
+
+type TicketData = {
+  id: string;
+  expiryDate: string;
+};
+
+function getRandomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+// API가 만들어지면 아래 getRandomDateTime 함수는 삭제 예정.
+function getRandomDateTime(): string {
+  const year = getRandomInt(2023, 2030);
+  const month = getRandomInt(1, 12)
+    .toString()
+    .padStart(2, '0');
+  const day = getRandomInt(1, 28)
+    .toString()
+    .padStart(2, '0'); // 최대값을 28로 설정하여 모든 달에서 유효한 날짜를 얻습니다.
+  const hour = getRandomInt(0, 23)
+    .toString()
+    .padStart(2, '0');
+  const minute = getRandomInt(0, 59)
+    .toString()
+    .padStart(2, '0');
+  const second = getRandomInt(0, 59)
+    .toString()
+    .padStart(2, '0');
+
+  return `${year}${month}${day}${hour}${minute}${second}`;
+}
+
+const useBarcode = () => {
+  const [barcodeDataURL, setBarcodeDataURL] = useState<
+    string | null
+  >(null);
+
+  const [ticketData, setTicketData] = useState<TicketData>({
+    id: '1234567890',
+    expiryDate: '20230706143699',
+  });
+
+  const generateBarcodeData = (text: string): string => {
+    const canvas = document.createElement('canvas');
+    bwipjs.toCanvas(canvas, {
+      bcid: 'code128',
+      textyoffset: 5,
+      text,
+      scale: 3,
+      height: 10,
+    });
+    return canvas.toDataURL();
+  };
+
+  const regenerateBarcode = () => {
+    // 여기에서 바코드 데이터를 변경하고 다시 생성합니다. -> 서버 api로 바코드 수정예정
+    const newExpiryDate = getRandomDateTime();
+
+    setTicketData((prev) => ({
+      ...prev,
+      expiryDate: newExpiryDate,
+    }));
+  };
+
+  useEffect(() => {
+    const dataURL = generateBarcodeData(
+      ticketData.expiryDate,
+    );
+    setBarcodeDataURL(dataURL);
+  }, [ticketData.expiryDate]);
+
+  return {
+    barcodeDataURL,
+    expiryDate: ticketData.expiryDate,
+    regenerateBarcode,
+  };
+};
+
+export default useBarcode;

--- a/src/types/bwip-js.d.ts
+++ b/src/types/bwip-js.d.ts
@@ -1,0 +1,12 @@
+declare module 'bwip-js' {
+  // `bwip-js` 라이브러리의 타입을 이곳에 정의합니다.
+  // 필요한 함수나 변수에 대한 타입만 간략하게 추가할 수 있습니다.
+
+  // eslint-disable-next-line no-unused-vars
+  function toCanvas(
+    // eslint-disable-next-line no-unused-vars
+    canvas: HTMLCanvasElement,
+    // eslint-disable-next-line no-unused-vars
+    options: any,
+  ): void;
+}


### PR DESCRIPTION

<img width="596" alt="Screen Shot 2023-10-01 at 4 07 56 PM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/6e682049-9fe1-4511-a3c8-c8256f972096">

바코드 생성하는 라이브러리로 bwip-js 사용하여 만들어보았습니다.
atoms역할을 하는 barcode 컴포넌트는 데이터를 props로 받아 화면에 그려주는 역할만,

바코드를 생성하는 비즈니스로직은 useBarcode 에서 작성했어요!
바코드 유효기간 오른쪽에 있는 아이콘은 차후에 새로고침 아이콘으로 변경예정이고,
useBarcode에서 임시로 만든 함수는 서버 바코드 생성 api가 만들어지면 삭제 예정이에요
