### PR TITLE
🚧 feat: create TitleHeader

### DIFF
--- a/src/components/common/molecules/TitleHeader/TitleHeader.stories.mdx
+++ b/src/components/common/molecules/TitleHeader/TitleHeader.stories.mdx
@@ -1,0 +1,40 @@
+import {
+  Meta,
+  Canvas,
+  ArgsTable,
+  Story,
+} from '@storybook/blocks';
+import { action } from '@storybook/addon-actions';
+
+import TitleHeader from '.';
+
+<Meta
+  title="molecules/TitleHeader"
+  component={TitleHeader}
+/>
+
+# TitleHeader
+
+프로젝트 내에서 홈, 마이페이지에서 사용되어지는 Title + 특정 페이지로 이동되도록 하는 기능을 포함한 컴포넌트입니다.
+
+## Props
+
+```ts
+interface TitleHeaderProps {
+  // Title 제목
+  title: string;
+  // 특정 페이지로 이동하는 콜백함수
+  handleGotoRouter: () => void;
+}
+```
+
+### TitleHeader
+
+- TitleHeader 예제입니다.
+
+<Canvas>
+  <TitleHeader
+    title="티켓 오픈예정 리스트"
+    handleGoToRouter={action('go router')}
+  />
+</Canvas>

--- a/src/components/common/molecules/TitleHeader/TitleHeader.stories.tsx
+++ b/src/components/common/molecules/TitleHeader/TitleHeader.stories.tsx
@@ -1,0 +1,21 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta } from '@storybook/react';
+import React from 'react';
+
+import TitleHeader from '.';
+
+const meta: Meta<typeof TitleHeader> = {
+  title: 'molecules/TitleHeader',
+  component: TitleHeader,
+};
+
+export default meta;
+
+export const CommonTitleHeader = {
+  render: () => (
+    <TitleHeader
+      title="티켓 오픈예정 리스트"
+      handleGoToRouter={action('go router')}
+    />
+  ),
+};

--- a/src/components/common/molecules/TitleHeader/index.tsx
+++ b/src/components/common/molecules/TitleHeader/index.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+import Text from '@/components/common/atoms/Text';
+import { flexbox } from '@/styles/mixin';
+
+import Icon from '../../atoms/Icon';
+
+interface TitleHeaderProps {
+  title: string;
+  handleGoToRouter: () => void;
+}
+
+const TitleHeaderWrapper = styled.div`
+  ${flexbox({ jc: 'space-between' })}
+`;
+
+const TitleHeader = ({
+  title,
+  handleGoToRouter,
+}: TitleHeaderProps) => (
+  <TitleHeaderWrapper>
+    <Text textSize="medium">{title}</Text>
+    <Icon
+      // TODO: Icon 변경 예정
+      iconName="searchIcon"
+      color="white"
+      iconSize="small"
+      onClick={handleGoToRouter}
+    />
+  </TitleHeaderWrapper>
+);
+
+export default TitleHeader;


### PR DESCRIPTION
<img width="344" alt="Screen Shot 2023-10-02 at 1 34 00 PM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/e0a141f9-4bb0-42cd-aee7-833c270f1df5">
<img width="344" alt="Screen Shot 2023-10-02 at 1 33 57 PM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/e04ec3bb-019f-4663-a4dc-ed9d8c0c8f41">

Title 과 특정 페이지로 이동하는 아이콘이 결합된 molecules 컴포넌트입니다! (홈페이지, 마이페이지에서 사용되어지는 걸로 보여요)