### PR TITLE
🚧 feat : create mini favorite component

### DIFF
--- a/src/assets/icon/close.svg
+++ b/src/assets/icon/close.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 17L16.8995 7.10051" stroke="#fff" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 7.00001L16.8995 16.8995" stroke="#fff" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/plus.svg
+++ b/src/assets/icon/plus.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="15" height="15" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 12H20M12 4V20" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/molecules/MiniFavorite/MiniFavorite.stories.mdx
+++ b/src/components/common/molecules/MiniFavorite/MiniFavorite.stories.mdx
@@ -1,0 +1,41 @@
+import {
+  Meta,
+  Canvas,
+  ArgsTable,
+  Story,
+} from '@storybook/blocks';
+
+import MiniFavorite from '.';
+
+<Meta
+  title="molecules/MiniFavorite"
+  component={MiniFavorite}
+/>
+
+# Label
+
+선호하는 아티스트, 장르를 선택한 경우 하단에 보이는 MiniFavorite 컴포넌트 입니다.
+
+( 테두리가 하얀 색이라 흰 배경에서 테두리는 보이지 않습니다! )
+
+## Props
+
+```ts
+  text?: string;  // 들어갈 내용
+background?: string;  // 선택한 아티스트의 사진이 있을 경우 해당 url주소
+favType?: FavType;  // 선택했는지 아닌지 'active' , 'none'이 있다!
+```
+
+### MiniFavorite
+
+- 하단 MiniFavorite 예제입니다.
+
+<Canvas>
+  <MiniFavorite />
+  <MiniFavorite text="R&B" />
+  <MiniFavorite
+    text="Aminé"
+    favType="active"
+    background="https://i.namu.wiki/i/OEKgiG-EKVByxF_x2ZdJ0VyaRCNmv-lGIoMR7fgKvWSP2zARUHOdD-vaHAVr65EKVR6Wy88xdZybivv_MYrIUg.webp"
+  />
+</Canvas>

--- a/src/components/common/molecules/MiniFavorite/MiniFavorite.stories.tsx
+++ b/src/components/common/molecules/MiniFavorite/MiniFavorite.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta } from '@storybook/react';
+import React from 'react';
+
+import MiniFavorite from '.';
+
+const meta: Meta<typeof MiniFavorite> = {
+  title: 'molecules/MiniFavorite',
+  component: MiniFavorite,
+};
+
+export default meta;
+
+export const MiniFav = {
+  render: () => <MiniFavorite />,
+};

--- a/src/components/common/molecules/MiniFavorite/index.tsx
+++ b/src/components/common/molecules/MiniFavorite/index.tsx
@@ -1,0 +1,108 @@
+import styled from 'styled-components';
+
+import { flexbox } from '@/styles/mixin';
+
+import Icon from '../../atoms/Icon';
+import Text from '../../atoms/Text';
+
+type FavType = 'active' | 'none';
+
+interface FavoriteProps {
+  text?: string;
+  background?: string;
+  favType?: FavType;
+}
+
+const FavoriteWrapper = styled.div<FavoriteProps>`
+  width: 94px;
+  height: 70px;
+  border-radius: 5.5px;
+
+  border: ${({ favType }) => {
+    switch (favType) {
+      case 'active':
+        return '1.5px solid #fff';
+      case 'none':
+        return '1.5px dashed #fff';
+      default:
+        return '1.5px dashed #fff';
+    }
+  }};
+  background-image: url(${({ background }) => background});
+  background-size: cover;
+  background-position: center;
+`;
+
+const Favorite = styled.div<FavoriteProps>`
+  ${flexbox({ jc: 'center', ai: 'center' })}
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 5.5px;
+
+  background: linear-gradient(
+    0deg,
+    rgba(72, 69, 204, 0.58) 12.31%,
+    rgba(255, 176, 158, 0.65) 99.54%
+  );
+`;
+
+const TextWrapper = styled.div`
+  margin-top: 5px;
+`;
+
+const IconWrapper = styled.div`
+  position: absolute;
+  top: 4px;
+  right: 4px;
+`;
+
+const MiniFavorite = ({
+  text,
+  background,
+  favType,
+}: FavoriteProps) => {
+  const handleMiniFavorite = () => {
+    // TODO (fav 삭제)
+  };
+  return (
+    <FavoriteWrapper
+      favType={favType}
+      background={background}
+    >
+      {text ? (
+        <Favorite favType={favType}>
+          <IconWrapper>
+            <Icon
+              iconName="close"
+              iconSize="small"
+              color="#fff"
+              onClick={() => handleMiniFavorite()}
+            />
+          </IconWrapper>
+          <TextWrapper>
+            <Text
+              variant="title"
+              textSize="small"
+              textColor="#fff"
+              textType="bold"
+            >
+              {text}
+            </Text>
+          </TextWrapper>
+        </Favorite>
+      ) : (
+        <Favorite>
+          <TextWrapper>
+            <Icon
+              iconName="plus"
+              iconSize="small"
+              color="#fff"
+            />
+          </TextWrapper>
+        </Favorite>
+      )}
+    </FavoriteWrapper>
+  );
+};
+export default MiniFavorite;

--- a/src/utils/iconMap.ts
+++ b/src/utils/iconMap.ts
@@ -17,7 +17,9 @@ export type SVGIconKeys =
   | 'openExpectedIcon'
   | 'mypageIcon'
   | 'bellIcon'
-  | 'heartIcon';
+  | 'heartIcon'
+  | 'plus'
+  | 'close';
 // 필요한 키들을 추가
 
 const SVG_ICON_MAP = {
@@ -42,6 +44,8 @@ const SVG_ICON_MAP = {
   ),
   bellIcon: lazy(() => import('@/assets/icon/bell.svg')),
   heartIcon: lazy(() => import('@/assets/icon/heart.svg')),
+  plus: lazy(() => import('@/assets/icon/plus.svg')),
+  close: lazy(() => import('@/assets/icon/close.svg')),
 };
 
 export default SVG_ICON_MAP;


### PR DESCRIPTION
<img width="511" alt="스크린샷 2023-10-05 오후 9 09 50" src="https://github.com/Muscat-Lab/TITO_frontend/assets/48702029/89712ba2-69a6-4291-b0c8-34b224064907">

<img width="432" alt="스크린샷 2023-10-05 오후 9 20 06" src="https://github.com/Muscat-Lab/TITO_frontend/assets/48702029/a63236a1-0d83-4228-8842-0e2570af35b6">


-> 피그마에서 위에 투명한 검정 그라데이션을 맨위에서 덮고 있어서 지금은 조금  색감이 다르게 보입니다!!

회원 가입시 좋아하는 장르나, 아티스트를 선택하고 아래에 보일수 있는 mini favorite component를 만들어 보았습니다!
이미지 같은 경우 위에서 선택한 이미지의 url을 받아서 배경으로 설정하게 되는데, 이 방법이 괜찮은 방법일지 궁금합니다!