### PR TITLE
🚧 feat/molecules circle icon

### DIFF
--- a/src/components/common/molecules/CircleIcon/CircleIcon.stories.mdx
+++ b/src/components/common/molecules/CircleIcon/CircleIcon.stories.mdx
@@ -1,0 +1,35 @@
+import {
+  Meta,
+  Canvas,
+  ArgsTable,
+  Story,
+} from '@storybook/blocks';
+
+import CircleIcon from '.';
+import Icon from '@/components/common/atoms/Icon';
+
+<Meta title="molecules/CircleIcon" component={CircleIcon} />
+
+# Label
+
+프로젝트 내에서 Icon을 감싸며 circle 형태의 컴포넌트를 표현합니다.
+
+## Props
+
+```ts
+
+```
+
+### CircleIcon
+
+- CircleIcon 컴포넌트 예제입니다.
+
+<Canvas>
+  <CircleIcon>
+    <Icon
+      iconName="bellIcon"
+      iconSize="small"
+      color="white"
+    />
+  </CircleIcon>
+</Canvas>

--- a/src/components/common/molecules/CircleIcon/CircleIcon.stories.mdx
+++ b/src/components/common/molecules/CircleIcon/CircleIcon.stories.mdx
@@ -4,6 +4,7 @@ import {
   ArgsTable,
   Story,
 } from '@storybook/blocks';
+import { action } from '@storybook/addon-actions';
 
 import CircleIcon from '.';
 import Icon from '@/components/common/atoms/Icon';
@@ -17,7 +18,15 @@ import Icon from '@/components/common/atoms/Icon';
 ## Props
 
 ```ts
-
+type SizeType = 'small' | 'medium' | 'large';
+interface circleIconProps {
+  // circleIcon 사이즈 단위! 'small', 'medium','large'가 있다.
+  circleIconSize: SizeType;
+  // 버튼 children Element (circleIcon에 들어가는 icon component)
+  children: React.ReactNode;
+  // icon 활성화 여부
+  isActive: boolean;
+}
 ```
 
 ### CircleIcon
@@ -25,11 +34,25 @@ import Icon from '@/components/common/atoms/Icon';
 - CircleIcon 컴포넌트 예제입니다.
 
 <Canvas>
-  <CircleIcon>
+  <CircleIcon circleIconSize="small">
     <Icon
       iconName="bellIcon"
       iconSize="small"
-      color="white"
+      color="#fff"
+    />
+  </CircleIcon>
+  <CircleIcon circleIconSize="medium">
+    <Icon
+      iconName="heartIcon"
+      iconSize="medium"
+      color="red"
+    />
+  </CircleIcon>
+  <CircleIcon circleIconSize="large">
+    <Icon
+      iconName="heartIcon"
+      iconSize="large"
+      color="#fff"
     />
   </CircleIcon>
 </Canvas>

--- a/src/components/common/molecules/CircleIcon/CircleIcon.stories.tsx
+++ b/src/components/common/molecules/CircleIcon/CircleIcon.stories.tsx
@@ -14,11 +14,11 @@ export default meta;
 
 export const CommonCircleIcon = {
   return: () => (
-    <CircleIcon>
+    <CircleIcon circleIconSize="medium" isActive={false}>
       <Icon
         iconName="bellIcon"
-        iconSize="small"
-        color="white"
+        iconSize="medium"
+        color="#fff"
       />
     </CircleIcon>
   ),

--- a/src/components/common/molecules/CircleIcon/CircleIcon.stories.tsx
+++ b/src/components/common/molecules/CircleIcon/CircleIcon.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta } from '@storybook/react';
+import React from 'react';
+
+import Icon from '@/components/common/atoms/Icon';
+
+import CircleIcon from '.';
+
+const meta: Meta<typeof CircleIcon> = {
+  title: 'molecules/CircleIcon',
+  component: CircleIcon,
+};
+
+export default meta;
+
+export const CommonCircleIcon = {
+  return: () => (
+    <CircleIcon>
+      <Icon
+        iconName="bellIcon"
+        iconSize="small"
+        color="white"
+      />
+    </CircleIcon>
+  ),
+};

--- a/src/components/common/molecules/CircleIcon/index.tsx
+++ b/src/components/common/molecules/CircleIcon/index.tsx
@@ -3,20 +3,62 @@ import styled from 'styled-components';
 
 import { flexbox } from '@/styles/mixin';
 
+type SizeType = 'small' | 'medium' | 'large';
 interface CircleIconProps {
+  circleIconSize: SizeType;
+  isActive: boolean;
   children: React.ReactNode;
 }
 
-const CircleIconWrapper = styled.div`
+const CircleIconWrapper = styled.div<{
+  circleIconSize: SizeType;
+  isActive: boolean;
+}>`
   ${flexbox({ jc: 'center', ai: 'center' })}
-  width: 20px;
-  height: 20px;
   border-radius: 50%;
   background: #1e1e1e;
+  cursor: pointer;
+
+  width: ${({ circleIconSize }) => {
+    switch (circleIconSize) {
+      case 'small':
+        return '20px';
+      case 'medium':
+        return '30px';
+      case 'large':
+        return '40px';
+      default:
+        return '30px';
+    }
+  }};
+
+  height: ${({ circleIconSize }) => {
+    switch (circleIconSize) {
+      case 'small':
+        return '20px';
+      case 'medium':
+        return '30px';
+      case 'large':
+        return '40px';
+      default:
+        return '30px';
+    }
+  }};
 `;
 
-const CircleIcon = ({ children }: CircleIconProps) => (
-  <CircleIconWrapper>{children}</CircleIconWrapper>
-);
+const CircleIcon = ({
+  circleIconSize,
+  isActive,
+  children,
+}: CircleIconProps) => {
+  return (
+    <CircleIconWrapper
+      circleIconSize={circleIconSize}
+      isActive={isActive}
+    >
+      {children}
+    </CircleIconWrapper>
+  );
+};
 
 export default CircleIcon;

--- a/src/components/common/molecules/CircleIcon/index.tsx
+++ b/src/components/common/molecules/CircleIcon/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { flexbox } from '@/styles/mixin';
+
+interface CircleIconProps {
+  children: React.ReactNode;
+}
+
+const CircleIconWrapper = styled.div`
+  ${flexbox({ jc: 'center', ai: 'center' })}
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #1e1e1e;
+`;
+
+const CircleIcon = ({ children }: CircleIconProps) => (
+  <CircleIconWrapper>{children}</CircleIconWrapper>
+);
+
+export default CircleIcon;

--- a/src/components/common/organisms/home/ScheduleInfoCard/index.tsx
+++ b/src/components/common/organisms/home/ScheduleInfoCard/index.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import Icon from '@/components/common/atoms/Icon';
 import Text from '@/components/common/atoms/Text';
+import CircleIcon from '@/components/common/molecules/CircleIcon';
 import { flexbox } from '@/styles/mixin';
 
 interface ScheduleInfoCardProps {
@@ -44,12 +45,6 @@ const IconBox = styled.div`
   gap: 4px;
 `;
 
-const IconInner = styled.div`
-  ${flexbox({ jc: 'center', ai: 'center' })}
-  border-radius: 32px;
-  background: #1e1e1e;
-`;
-
 const ScheduleInfoCard = ({
   id,
   bgPath,
@@ -77,20 +72,20 @@ const ScheduleInfoCard = ({
         </Text>
       </TextBox>
       <IconBox>
-        <IconInner>
+        <CircleIcon>
           <Icon
             iconName="bellIcon"
             iconSize="small"
             color="white"
           />
-        </IconInner>
-        <IconInner>
+        </CircleIcon>
+        <CircleIcon>
           <Icon
             iconName="heartIcon"
             iconSize="small"
             color="white"
           />
-        </IconInner>
+        </CircleIcon>
       </IconBox>
     </ContentBox>
   </ScheduleInfoCardWrapper>


### PR DESCRIPTION
<img width="52" alt="Screenshot 2023-10-15 at 5 02 14 PM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/306e237d-a07c-44cc-b9a9-68f544a2a423">
<img width="76" alt="Screenshot 2023-10-15 at 5 02 16 PM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/e60436f3-5d84-46a2-95cf-9b1884b9fd11">

위 두 컴포넌트에서 Icon과 wrapper를 합쳐 사용되어지는 컴포넌트를 circle-icon으로 만들었어요.
작업하다보니, Icon Component에 width, height 값이 먹히지 않는다는걸 알게되어.. 이 부분 수정이 필요해보여서 요 Icon 컴포넌트 문제는 브랜치 하나 파서 작업할게여