### PR TITLE
🚧 feat: create tabs component

### DIFF
--- a/src/components/common/molecules/Tabs/Tabs.stories.mdx
+++ b/src/components/common/molecules/Tabs/Tabs.stories.mdx
@@ -1,0 +1,44 @@
+import {
+  Meta,
+  Canvas,
+  ArgsTable,
+  Story,
+} from '@storybook/blocks';
+import { action } from '@storybook/addon-actions';
+
+import Tabs from '.';
+
+<Meta title="molecules/Tabs" component={Tabs} />
+
+# Tabs
+
+전반적인 예매 화면에서 사용되어지는 Tabs 컴포넌트입니다.
+
+## Props
+
+```ts
+interface TabsProps {
+  // tabs 컴포넌트를 이루는 아이템항목들
+  tabItems: string[];
+  // 현재 클릭된 tab의 idx
+  activeIdx: number;
+  // tab을 클릭했을때 실행되는 콜백함수
+  onClick: () => void;
+}
+```
+
+### Tabs
+
+- Tabs 예제입니다.
+
+<Canvas>
+  <Tabs
+    tabItems={[
+      '공연상세정보',
+      '공연장정보',
+      '취소 및 환불규정',
+    ]}
+    activeIdx={2}
+    onClick={action('clicked tab')}
+  />
+</Canvas>

--- a/src/components/common/molecules/Tabs/Tabs.stories.tsx
+++ b/src/components/common/molecules/Tabs/Tabs.stories.tsx
@@ -1,0 +1,26 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta } from '@storybook/react';
+import React from 'react';
+
+import Tabs from '.';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'molecules/Tabs',
+  component: Tabs,
+};
+
+export default meta;
+
+export const CommonTabs = {
+  render: () => (
+    <Tabs
+      tabItems={[
+        '공연상세정보',
+        '공연장정보',
+        '취소 및 환불규정',
+      ]}
+      activeIdx={2}
+      onClick={action('clicked tab')}
+    />
+  ),
+};

--- a/src/components/common/molecules/Tabs/index.tsx
+++ b/src/components/common/molecules/Tabs/index.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+
+import { flexbox } from '@/styles/mixin';
+import { useState } from 'react';
+import Text from '../../atoms/Text';
+
+interface TabsProps {
+  tabItems: string[];
+  activeIdx: number;
+  onClick: () => void;
+}
+
+const TabsWrapper = styled.div`
+  ${flexbox({ jc: 'space-between' })}
+  width: 100%;
+`;
+
+const TabWrapper = styled.div<{ isActive: boolean }>`
+  ${flexbox({ ai: 'center' })}
+  border-bottom: 2px solid ${({ isActive }) =>
+    isActive ? '#4845cc' : 'transparent'};
+`;
+
+const Tab = styled.button`
+  outline: none;
+  border: none;
+  padding-bottom: 10px;
+  background: transparent;
+  cursor: pointer;
+`;
+
+const Tabs = ({
+  tabItems,
+  activeIdx,
+  onClick,
+}: TabsProps) => {
+  const [currentIdx, setCurrentIdx] = useState(2);
+
+  const handleClickTab = (idx: number) => {
+    setCurrentIdx(idx);
+    onClick();
+  };
+
+  return (
+    <TabsWrapper>
+      {tabItems.map((item, idx) => {
+        const isActive = currentIdx === idx;
+
+        return (
+          <TabWrapper key={item} isActive={isActive}>
+            <Tab onClick={() => handleClickTab(idx)}>
+              <Text
+                textSize="small"
+                textColor={isActive ? '#fff' : '#616161'}
+              >
+                {item}
+              </Text>
+            </Tab>
+          </TabWrapper>
+        );
+      })}
+    </TabsWrapper>
+  );
+};
+
+export default Tabs;


### PR DESCRIPTION
<img width="294" alt="Screenshot 2023-10-22 at 12 32 43 AM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/20a8d662-e52c-44e2-bd50-9204adc4223b">
<img width="382" alt="Screenshot 2023-10-22 at 12 32 50 AM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/6f7744da-ed44-46ed-8968-2c75445eef7f">
<img width="306" alt="Screenshot 2023-10-22 at 12 33 01 AM" src="https://github.com/Muscat-Lab/TITO_frontend/assets/45479309/dd55dc4e-24a2-4498-a47c-dc7dee1417c3">

예매화면, 마이페이지에서 공통으로 사용되어지는 Tabs컴포넌트를 만들어보았습니다.
tabs를 이루는 아이템의 항목을 스트링 배열형태로 받게 하였고, 선택된 tab인지 체킹하는 activeIdx 그리고...

onClick props 에 따라 Tabs 아래에 나타나는 영역이 변경되어질 것 같은데 이 영역을 상위 컴포넌트에서 switch문으로 구별하는게 최선일지 고민하고 있긴해요..!
